### PR TITLE
Improve: set `SWAN_PATH` by environment variable

### DIFF
--- a/build_from_source.sh
+++ b/build_from_source.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
+SWAN_PATH=$(echo ${SWAN_PATH})
 CONF_FILE_DIR=${HOME}/.swan/provider
+
+if [ -n "$SWAN_PATH" ]; then
+  CONF_FILE_DIR=$SWAN_PATH/provider
+fi
 
 if [ ! -d "${CONF_FILE_DIR}" ]; then
     mkdir -p ${CONF_FILE_DIR}

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ type main struct {
 	LotusImportInterval      time.Duration `toml:"import_interval"`
 	LotusScanInterval        time.Duration `toml:"scan_interval"`
 	MarketVersion            string        `toml:"market_version"`
+	SwanRepoPath             string        `toml:"swan_repo_path"`
 }
 
 type bid struct {
@@ -66,12 +67,19 @@ type market struct {
 var config *Configuration
 
 func InitConfig() {
-	homedir, err := os.UserHomeDir()
-	if err != nil {
-		logs.GetLogger().Fatal("Cannot get home directory.")
+	swanPath, exist := os.LookupEnv("SWAN_PATH")
+	var basePath, configFile string
+	if exist {
+		configFile = filepath.Join(swanPath, "provider/config.toml")
+		basePath = filepath.Join(swanPath, "provider")
+	} else {
+		homedir, err := os.UserHomeDir()
+		if err != nil {
+			logs.GetLogger().Fatal("Cannot get home directory.")
+		}
+		configFile = filepath.Join(homedir, ".swan/provider/config.toml")
+		basePath = filepath.Join(homedir, ".swan/provider")
 	}
-
-	configFile := filepath.Join(homedir, ".swan/provider/config.toml")
 
 	logs.GetLogger().Info("Your config file is:", configFile)
 
@@ -82,10 +90,8 @@ func InitConfig() {
 			logs.GetLogger().Fatal("required fields not given")
 		}
 	}
-
-	config.Market.Repo = filepath.Join(homedir, ".swan/provider/boost")
-	config.Market.BoostLog = filepath.Join(homedir, ".swan/provider/boost.log")
-
+	config.Market.Repo = filepath.Join(basePath, "boost")
+	config.Market.BoostLog = filepath.Join(basePath, "boost.log")
 }
 
 func GetConfig() Configuration {
@@ -125,6 +131,7 @@ func requiredFieldsAreGiven(metaData toml.MetaData) bool {
 		{"main", "access_token"},
 		{"main", "api_heartbeat_interval"},
 		{"main", "market_version"},
+		{"main", "swan_repo_path"},
 
 		{"bid", "bid_mode"},
 		{"bid", "expected_sealing_time"},

--- a/config/config.go
+++ b/config/config.go
@@ -44,7 +44,6 @@ type main struct {
 	LotusImportInterval      time.Duration `toml:"import_interval"`
 	LotusScanInterval        time.Duration `toml:"scan_interval"`
 	MarketVersion            string        `toml:"market_version"`
-	SwanRepoPath             string        `toml:"swan_repo_path"`
 }
 
 type bid struct {
@@ -131,7 +130,6 @@ func requiredFieldsAreGiven(metaData toml.MetaData) bool {
 		{"main", "access_token"},
 		{"main", "api_heartbeat_interval"},
 		{"main", "market_version"},
-		{"main", "swan_repo_path"},
 
 		{"bid", "bid_mode"},
 		{"bid", "expected_sealing_time"},

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-BINARY_NAME=swan-provider-2.0.0-linux-amd64
-TAG_NAME=v2.0.0
+BINARY_NAME=swan-provider-2.1.0-rc1-linux-amd64
+TAG_NAME=v2.1.0-rc1
 URL_PREFIX=https://github.com/filswan/go-swan-provider/releases/download
 
 wget --no-check-certificate ${URL_PREFIX}/${TAG_NAME}/${BINARY_NAME}
@@ -10,6 +10,11 @@ wget --no-check-certificate ${URL_PREFIX}/${TAG_NAME}/aria2c.service
 wget --no-check-certificate ${URL_PREFIX}/${TAG_NAME}/config.toml.example
 
 CONF_FILE_DIR=${HOME}/.swan/provider
+SWAN_PATH=$(echo ${SWAN_PATH})
+if [ -n "$SWAN_PATH" ]; then
+  CONF_FILE_DIR=$SWAN_PATH/provider
+fi
+
 mkdir -p ${CONF_FILE_DIR}
 
 CONF_FILE_PATH=${CONF_FILE_DIR}/config.toml


### PR DESCRIPTION
You can set `SWAN_PATH` by environment variable, for example: `export SWAN_PATH="/data/.swan`