### PR TITLE
Improve: add the cmd `set-ask` and handle the empty deal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Khan/genqlient v0.5.0
 	github.com/fatih/color v1.13.0
 	github.com/filecoin-project/go-jsonrpc v0.1.9 // indirect
-	github.com/filswan/go-swan-lib v0.2.132-0.20230103113208-178966202a6e
+	github.com/filswan/go-swan-lib v0.2.132-0.20230106055204-307c6ccdadb5
 	github.com/gin-gonic/gin v1.7.4
 	github.com/google/uuid v1.3.0
 	github.com/itsjamie/gin-cors v0.0.0-20160420130702-97b4a9da7933

--- a/go.sum
+++ b/go.sum
@@ -468,8 +468,8 @@ github.com/filecoin-project/specs-storage v0.4.1/go.mod h1:Z2eK6uMwAOSLjek6+sy0j
 github.com/filecoin-project/storetheindex v0.4.17 h1:w0dVc954TGPukoVbidlYvn9Xt+wVhk5vBvrqeJiRo8I=
 github.com/filecoin-project/storetheindex v0.4.17/go.mod h1:y2dL8C5D3PXi183hdxgGtM8vVYOZ1lg515tpl/D3tN8=
 github.com/filecoin-project/test-vectors/schema v0.0.5/go.mod h1:iQ9QXLpYWL3m7warwvK1JC/pTri8mnfEmKygNDqqY6E=
-github.com/filswan/go-swan-lib v0.2.132-0.20230103113208-178966202a6e h1:ymlwu7Q50e58rNmUrb34WSAEeVAMv4T34RDK4V+R9ss=
-github.com/filswan/go-swan-lib v0.2.132-0.20230103113208-178966202a6e/go.mod h1:D6mgGrbXcv7kHQKOmeJdqIbUzl5DxmBuCiKzfa8Jh0A=
+github.com/filswan/go-swan-lib v0.2.132-0.20230106055204-307c6ccdadb5 h1:REh4W1VnjSvrGHvFnR7u+9S66XncujPhlaJJqcj0su8=
+github.com/filswan/go-swan-lib v0.2.132-0.20230106055204-307c6ccdadb5/go.mod h1:D6mgGrbXcv7kHQKOmeJdqIbUzl5DxmBuCiKzfa8Jh0A=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=

--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ func printUsage() {
 	fmt.Println("USAGE:")
 	fmt.Println("    swan-provider version")
 	fmt.Println("    swan-provider daemon")
+	fmt.Println("    swan-provider set-ask --price=xx --verified-price=xx --min-piece-size=xx --max-piece-size=xx")
 }
 
 func createHttpServer() {

--- a/main.go
+++ b/main.go
@@ -109,6 +109,7 @@ func setAsk() {
 	verifiedPrice := flag.String("verified-price", "0", "Set the price of the ask for verified deals (specified as FIL / GiB / Epoch) to `PRICE`")
 	minSize := flag.String("min-piece-size", "256B", "Set minimum piece size (w/bit-padding, in bytes) in ask to `SIZE`")
 	maxSize := flag.String("max-piece-size", "0", "Set maximum piece size (w/bit-padding, in bytes) in ask to `SIZE`")
+	flag.Parse()
 
 	market := config.GetConfig().Market
 	boostToken, err := service.GetBoostToken(market.Repo)

--- a/service/common.go
+++ b/service/common.go
@@ -451,7 +451,7 @@ func StopBoost(pid int) {
 	logs.GetLogger().Info("stop boostd successful")
 }
 
-func getBoostToken(repo string) (string, error) {
+func GetBoostToken(repo string) (string, error) {
 	tokenFile, err := ioutil.ReadFile(path.Join(repo, "token"))
 	if err != nil {
 		log.Println(err)

--- a/service/lotus.go
+++ b/service/lotus.go
@@ -174,8 +174,9 @@ func (lotusService *LotusService) StartScan(swanClient *swan.SwanClient) {
 			if _, err := uuid.Parse(deal.DealCid); err == nil {
 				dealResp, err := hqlClient.GetDealByUuid(deal.DealCid)
 				if err != nil {
-					logs.GetLogger().Error(err)
-					return
+					logs.GetLogger().Errorf("taskName: %s, dealUuid: %s, get deal info failed, error: %+v", *deal.TaskName, deal.DealCid, err)
+					UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "not found the deal in the db")
+					continue
 				}
 				minerId = dealResp.Deal.GetProviderAddress()
 				dealId, err = strconv.ParseUint(dealResp.Deal.GetChainDealID().Value, 10, 64)
@@ -189,7 +190,8 @@ func (lotusService *LotusService) StartScan(swanClient *swan.SwanClient) {
 			} else {
 				dealResp, err := hqlClient.GetProposalCid(deal.DealCid)
 				if err != nil {
-					logs.GetLogger().Error(err)
+					logs.GetLogger().Errorf("taskName: %s, dealCid: %s, get deal info failed, error: %+v", *deal.TaskName, deal.DealCid, err)
+					UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "not found the deal in the db")
 					continue
 				}
 


### PR DESCRIPTION
* add the command `set-ask`:
```
./swan-provider set-ask --price=0 --verified-price=0 --min-piece-size=256 --max-piece-size=34359738368
```
* update deal status to `ImportFailed` when the deal cannot be queried from the database